### PR TITLE
Remove strict typing assertion from filterset.

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -222,9 +222,6 @@ class BaseFilterSet(object):
         """
         for name, value in self.form.cleaned_data.items():
             queryset = self.filters[name].filter(queryset, value)
-            assert isinstance(queryset, models.QuerySet), \
-                "Expected '%s.%s' to return a QuerySet, but got a %s instead." \
-                % (type(self).__name__, name, type(queryset).__name__)
         return queryset
 
     @property


### PR DESCRIPTION
It prevents mock querysets from being passed in without extensive mock-chaining specific to the filters being tested.